### PR TITLE
fix black.find_project_root usage

### DIFF
--- a/brunette/brunette.py
+++ b/brunette/brunette.py
@@ -192,7 +192,7 @@ def patched_normalize_string_quotes(s: str) -> str:
 
 def read_config_file(ctx, param, value):
     if not value:
-        root = black.find_project_root(ctx.params.get('src', ()))
+        root, _description = black.find_project_root(ctx.params.get('src', ()))
         path = root / 'setup.cfg'
         if path.is_file():
             value = str(path)

--- a/brunette/brunette.py
+++ b/brunette/brunette.py
@@ -439,7 +439,7 @@ def main(
     report = Report(check=check, quiet=quiet, verbose=verbose)
     root = find_project_root(src)
     sources: Set[Path] = set()
-    path_empty(src=src, quiet=quiet, verbose=verbose, ctx=ctx, msg=None)
+    path_empty(src=src, quiet=quiet, verbose=verbose, ctx=ctx, msg='')
     for s in src:
         p = Path(s)
         if p.is_dir():


### PR DESCRIPTION
`black.find_project_root` returns a tuple

from the docscring on `black.files.find_project_root`
> Returns a two-tuple with the first element as the project root path and the second element as a string describing the method by which the project root was discovered.